### PR TITLE
docs: fix incorrect zip packaging script names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,12 +199,12 @@ From the project root:
 #### Zip Archive
 
 **On Windows:**
-Run `.\gradlew build` and `.\package.bat` from the project root.
+Run `.\gradlew build` and then `.\package-zip.bat` from the project root.
+This will create `archive.zip` containing the application, run scripts, README, and LICENSE.
 
 **On Linux/Mac:**
-Run `./package.sh` from the project root.
-
-This will create `archive.zip` containing the application, run scripts, README, and LICENSE.
+Run `./gradlew build` and then `./package-zip.sh` from the project root.
+This will create `NumberGuessingGame-archive.zip` containing the application, run scripts, README, and LICENSE.
 
 #### Debian Package
 


### PR DESCRIPTION
## Summary

While reading through the README, I noticed the **Creating Release Archives → Zip Archive** section references two packaging scripts that don't exist in the repository:

- On Windows it instructs users to run `.\package.bat`
- On Linux/macOS it instructs users to run `./package.sh`

Neither of those files is present. The actual scripts are:

- `package-zip.bat` (Windows)
- `package-zip.sh` (Linux/macOS)

Following the current instructions verbatim produces a `command not found` / "is not recognized as an internal or external command" error.

## Changes

Updated the **Windows** step to:

```text
Run .\gradlew build and then .\package-zip.bat from the project root.
This will create archive.zip containing the application, run scripts, README, and LICENSE.
```

Updated the **Linux/Mac** step to:

```text
Run ./gradlew build and then ./package-zip.sh from the project root.
This will create NumberGuessingGame-archive.zip containing the application, run scripts, README, and LICENSE.
```

I also corrected the documented output artifact name per platform: `package-zip.bat` produces `archive.zip` (via PowerShell `Compress-Archive`), while `package-zip.sh` produces `NumberGuessingGame-archive.zip` (via the `zip` utility). Both names now match what the respective scripts actually generate.

## Verification

- Confirmed via repo file listing that the only packaging batch/shell scripts present are: `package-zip.bat`, `package-zip.sh`, `package-deb.sh`, `package-linux.sh`, `package-win.sh`, `package-macos.sh`, and `package-rpm.sh`.
- Confirmed the Windows `.bat` references `archive.zip` and the POSIX `.sh` references `NumberGuessingGame-archive.zip` in their respective archive-creation commands.
- No other packaging sections (Debian, RPM, platform-specific) referenced non-existent scripts, so they were left unchanged to keep this PR minimal and focused.

Docs-only change; no code or build behavior is affected.
